### PR TITLE
Add foundational unit tests for blackjack logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC_PATH))
+

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,123 @@
+from game import GameManager, GamePhase
+
+
+def sample_players():
+    return {
+        "p1": {"username": "Alice", "id": "sid1"},
+        "p2": {"username": "Bob", "id": "sid2"},
+    }
+
+
+def test_game_manager_create_and_get_game():
+    manager = GameManager()
+    room_game = manager.create_game("ROOM1", sample_players())
+
+    assert room_game.room_code == "ROOM1"
+    assert manager.get_game("ROOM1") is room_game
+
+
+def test_game_manager_end_game_removes_game():
+    manager = GameManager()
+    manager.create_game("ROOM1", sample_players())
+
+    manager.end_game("ROOM1")
+
+    assert manager.get_game("ROOM1") is None
+
+
+def test_room_game_initializes_players():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+
+    assert len(room_game.player_objects) == 2
+    assert len(room_game.game.players) == 2
+    assert room_game.phase == GamePhase.WAITING_FOR_BETS
+
+
+def test_place_bet_success():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+
+    result = room_game.place_bet("p1", 100)
+
+    assert result["success"] is True
+    assert room_game.player_bets["p1"] == 100
+    assert room_game.player_objects["p1"].balance == 900
+
+
+def test_place_bet_rejects_invalid_player():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+
+    result = room_game.place_bet("bad_id", 100)
+
+    assert result["error"] == "Player not in game."
+
+
+def test_place_bet_rejects_invalid_amount():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+
+    result = room_game.place_bet("p1", 5000)
+
+    assert result["error"] == "Invalid bet amount."
+
+
+def test_start_round_requires_all_bets():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.place_bet("p1", 100)
+
+    result = room_game.start_round()
+
+    assert result["error"] == "Not all players have placed bets."
+
+
+def test_start_round_transitions_to_playing():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.place_bet("p1", 100)
+    room_game.place_bet("p2", 150)
+
+    result = room_game.start_round()
+
+    assert room_game.phase == GamePhase.PLAYING
+    assert result["phase"] == "playing"
+    assert len(room_game.game.dealer_hand) == 2
+    assert len(room_game.player_objects["p1"].hand) == 2
+    assert len(room_game.player_objects["p2"].hand) == 2
+
+
+def test_get_game_state_returns_expected_structure():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+
+    state = room_game.get_game_state()
+
+    assert "phase" in state
+    assert "players" in state
+    assert "dealer_hand" in state
+    assert "current_player_index" in state
+    assert len(state["players"]) == 2
+
+
+def test_stand_in_wrong_phase_returns_error():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+
+    result = room_game.stand("p1")
+
+    assert result["error"] == "Not in playing phase."
+
+
+def test_hit_in_wrong_phase_returns_error():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+
+    result = room_game.hit("p1")
+
+    assert result["error"] == "Not in playing phase."
+
+
+def test_get_final_state_includes_dealer_value():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.place_bet("p1", 100)
+    room_game.place_bet("p2", 100)
+    room_game.start_round()
+
+    final_state = room_game.get_final_state()
+
+    assert "dealer_hand" in final_state
+    assert "dealer_value" in final_state
+

--- a/tests/test_rules_and_objects.py
+++ b/tests/test_rules_and_objects.py
@@ -1,0 +1,97 @@
+from rules_and_objects import Card, Deck, Player, Game, hand_value
+
+
+def test_card_string_representation():
+    card = Card("Hearts", "Ace")
+    assert str(card) == "Ace of Hearts"
+
+
+def test_hand_value_without_aces():
+    hand = [Card("Hearts", "10"), Card("Spades", "7")]
+    value, soft = hand_value(hand)
+    assert value == 17
+    assert soft is False
+
+
+def test_hand_value_with_soft_ace():
+    hand = [Card("Hearts", "Ace"), Card("Spades", "6")]
+    value, soft = hand_value(hand)
+    assert value == 17
+    assert soft is True
+
+
+def test_hand_value_with_ace_adjustment():
+    hand = [Card("Hearts", "Ace"), Card("Spades", "King"), Card("Clubs", "5")]
+    value, soft = hand_value(hand)
+    assert value == 16
+    assert soft is False
+
+
+def test_deck_builds_52_cards():
+    deck = Deck()
+    assert len(deck.cards) == 52
+
+
+def test_draw_card_reduces_deck_size():
+    deck = Deck()
+    original_size = len(deck.cards)
+    card = deck.draw_card()
+    assert isinstance(card, Card)
+    assert len(deck.cards) == original_size - 1
+
+
+def test_player_place_valid_bet():
+    player = Player("Luis")
+    success = player.place_bet(100)
+    assert success is True
+    assert player.bet == 100
+    assert player.balance == 900
+
+
+def test_player_rejects_invalid_bet():
+    player = Player("Luis")
+    assert player.place_bet(0) is False
+    assert player.place_bet(-5) is False
+    assert player.place_bet(2000) is False
+    assert player.balance == 1000
+
+
+def test_player_reset_hand_clears_state():
+    player = Player("Luis")
+    player.hand = [Card("Hearts", "10")]
+    player.is_bust = True
+    player.is_stand = True
+
+    player.reset_hand()
+
+    assert player.hand == []
+    assert player.is_bust is False
+    assert player.is_stand is False
+
+
+def test_player_stand_sets_flag():
+    player = Player("Luis")
+    player.stand()
+    assert player.is_stand is True
+
+
+def test_game_add_and_remove_player():
+    game = Game()
+    player = Player("Luis")
+    game.add_player(player)
+    assert player in game.players
+
+    game.remove_player(player)
+    assert player not in game.players
+
+
+def test_game_determine_winner_player_bust():
+    game = Game()
+    player = Player("Luis")
+    player.bet = 100
+    player.is_bust = True
+
+    outcome, payout = game.determine_winner(player)
+    assert outcome == "lose"
+    assert payout == 0
+


### PR DESCRIPTION
Adds initial pytest-based unit tests for core blackjack logic in src/rules_and_objects.py and src/game.py.

Includes 24 passing pytest tests and establishes the initial testing structure for the project.

Closes #22