### PR TITLE
Expand app.py handler unit tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 import re
+import asyncio
 from app import (
     ROOM_CODE_CHARS,
     generate_player_id,
@@ -10,6 +11,20 @@ from app import (
     normalize_ai_query,
     room_has_username,
     rooms,
+    ai_help,
+    game_start,
+    game_place_bet,
+    game_hit,
+    game_stand,
+    game_get_state,
+    game_next_round,
+    singleplayer_start,
+    player_rooms,
+    player_info,
+    rooms,
+    ai_help_last_request_at,
+    ai_help_in_flight,
+    GamePhase,
 )
 
 
@@ -120,3 +135,113 @@ def test_generate_room_code_avoids_existing_room_codes(monkeypatch):
     code = generate_room_code()
 
     assert code == "FGHIJ"
+def teardown_function():
+    rooms.clear()
+    player_rooms.clear()
+    player_info.clear()
+    ai_help_last_request_at.clear()
+    ai_help_in_flight.clear()
+
+
+def test_ai_help_rejects_invalid_payload():
+    result = asyncio.run(ai_help("sid1", "bad payload"))
+    assert result["error"] == "Invalid payload."
+
+
+def test_ai_help_requires_room_membership():
+    result = asyncio.run(ai_help("sid1", {}))
+    assert result["error"] == "Not in a room."
+
+
+def test_ai_help_requires_existing_room():
+    player_rooms["sid1"] = "ABCDE"
+    result = asyncio.run(ai_help("sid1", {}))
+    assert result["error"] == "Room not found."
+
+
+def test_ai_help_requires_existing_player_in_room():
+    player_rooms["sid1"] = "ABCDE"
+    rooms["ABCDE"] = {"players": []}
+    result = asyncio.run(ai_help("sid1", {}))
+    assert result["error"] == "Player not found."
+
+
+def test_ai_help_returns_error_when_chat_unavailable(monkeypatch):
+    player_rooms["sid1"] = "ABCDE"
+    rooms["ABCDE"] = {
+        "players": [{"id": "sid1", "username": "Luis"}]
+    }
+
+    monkeypatch.setattr("app.chat", None)
+
+    result = asyncio.run(ai_help("sid1", {}))
+    assert "AI helper is unavailable" in result["error"]
+
+
+def test_game_start_requires_room_membership():
+    result = asyncio.run(game_start("sid1"))
+    assert result["error"] == "Not in a room."
+
+
+def test_game_start_requires_host():
+    player_rooms["sid2"] = "ABCDE"
+    rooms["ABCDE"] = {
+        "host_id": "sid1",
+        "players": [{"id": "sid1", "username": "Luis", "ready": True, "player_id": "p1"}],
+        "game_started": False,
+    }
+
+    result = asyncio.run(game_start("sid2"))
+    assert result["error"] == "Only host can start the game."
+
+
+def test_game_start_requires_all_players_ready():
+    player_rooms["sid1"] = "ABCDE"
+    rooms["ABCDE"] = {
+        "host_id": "sid1",
+        "players": [
+            {"id": "sid1", "username": "Luis", "ready": True, "player_id": "p1"},
+            {"id": "sid2", "username": "Bob", "ready": False, "player_id": "p2"},
+        ],
+        "game_started": False,
+    }
+
+    result = asyncio.run(game_start("sid1"))
+    assert result["error"] == "All players must be ready."
+
+
+def test_game_place_bet_requires_room_membership():
+    result = asyncio.run(game_place_bet("sid1", {"amount": 50}))
+    assert result["error"] == "Not in a room."
+
+
+def test_game_hit_requires_room_membership():
+    result = asyncio.run(game_hit("sid1"))
+    assert result["error"] == "Not in a room."
+
+
+def test_game_stand_requires_room_membership():
+    result = asyncio.run(game_stand("sid1"))
+    assert result["error"] == "Not in a room."
+
+
+def test_game_get_state_requires_room_membership():
+    result = asyncio.run(game_get_state("sid1"))
+    assert result["error"] == "Not in a room."
+
+
+def test_game_next_round_requires_room_membership():
+    result = asyncio.run(game_next_round("sid1"))
+    assert result["error"] == "Not in a room."
+
+
+def test_singleplayer_start_requires_connection():
+    result = asyncio.run(singleplayer_start("sid1", {"username": "Luis"}))
+    assert result["error"] == "Not connected."
+
+
+def test_singleplayer_start_requires_username():
+    player_info["sid1"] = {"player_id": "p1"}
+
+    result = asyncio.run(singleplayer_start("sid1", {"username": "   "}))
+    assert result["error"] == "Username is required."

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,5 +1,5 @@
-from game import GameManager, GamePhase
-
+from types import SimpleNamespace
+from game import GameManager, GamePhase, RoomGame
 
 def sample_players():
     return {
@@ -166,3 +166,183 @@ def test_get_final_state_includes_dealer_value():
     assert "dealer_hand" in final_state
     assert "dealer_value" in final_state
 
+def sample_players():
+    return {
+        "p1": {"username": "Alice", "id": "sid1"},
+        "p2": {"username": "Bob", "id": "sid2"},
+    }
+
+
+def test_place_bet_rejects_when_not_waiting_for_bets():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+
+    result = room_game.place_bet("p1", 50)
+
+    assert result["error"] == "Not in betting phase."
+
+
+def test_hit_rejects_unknown_player_during_playing():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+
+    result = room_game.hit("bad_player")
+
+    assert result["error"] == "Player not found."
+
+
+def test_stand_rejects_unknown_player_during_playing():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+
+    result = room_game.stand("bad_player")
+
+    assert result["error"] == "Player not found."
+
+
+def test_hit_returns_game_state_when_player_does_not_bust(monkeypatch):
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+    player = room_game.player_objects["p1"]
+
+    monkeypatch.setattr(player, "hit", lambda deck: None)
+    monkeypatch.setattr(room_game, "get_game_state", lambda: {"phase": "playing"})
+
+    result = room_game.hit("p1")
+
+    assert result == {"phase": "playing"}
+
+
+def test_hit_advances_when_player_busts(monkeypatch):
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+    player = room_game.player_objects["p1"]
+
+    def fake_hit(deck):
+        player.is_bust = True
+
+    monkeypatch.setattr(player, "hit", fake_hit)
+    monkeypatch.setattr(room_game, "advance_to_next_player", lambda: {"phase": "dealer_turn"})
+
+    result = room_game.hit("p1")
+
+    assert result == {"phase": "dealer_turn"}
+
+
+def test_stand_marks_player_and_advances(monkeypatch):
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+    player = room_game.player_objects["p1"]
+
+    monkeypatch.setattr(room_game, "advance_to_next_player", lambda: {"phase": "dealer_turn"})
+
+    result = room_game.stand("p1")
+
+    assert player.is_stand is True
+    assert result == {"phase": "dealer_turn"}
+
+
+def test_advance_to_next_player_returns_state_if_active_players_remain(monkeypatch):
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+
+    room_game.player_objects["p1"].is_stand = True
+    room_game.player_objects["p2"].is_stand = False
+
+    monkeypatch.setattr(room_game, "get_game_state", lambda: {"phase": "playing", "current_player_index": 1})
+
+    result = room_game.advance_to_next_player()
+
+    assert result["phase"] == "playing"
+    assert room_game.current_player_index == 1
+
+
+def test_advance_to_next_player_finalizes_when_no_active_players(monkeypatch):
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+
+    room_game.player_objects["p1"].is_stand = True
+    room_game.player_objects["p2"].is_bust = True
+
+    monkeypatch.setattr(room_game.game, "finalize_round", lambda: {"Alice": {"outcome": "win"}})
+    monkeypatch.setattr(room_game.game, "get_dealer_hand_value", lambda: 20)
+    room_game.game.dealer_hand = []
+
+    result = room_game.advance_to_next_player()
+
+    assert result["phase"] == "round_complete"
+    assert result["results"]["Alice"]["outcome"] == "win"
+    assert room_game.phase == GamePhase.ROUND_COMPLETE
+
+
+def test_get_final_state_includes_full_dealer_hand(monkeypatch):
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.game.dealer_hand = []
+    monkeypatch.setattr(room_game, "get_game_state", lambda: {"phase": "playing", "dealer_hand": ["hidden"]})
+    monkeypatch.setattr(room_game.game, "get_dealer_hand_value", lambda: 18)
+
+    state = room_game.get_final_state()
+
+    assert "dealer_value" in state
+    assert state["dealer_value"] == 18
+
+
+def test_add_player_adds_to_room_game_mappings():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+
+    room_game.add_player("p3", "Cara", "sid3")
+
+    assert "p3" in room_game.player_objects
+    assert "p3" in room_game.players_dict
+    assert any(player.name == "Cara" for player in room_game.game.players)
+
+
+def test_remove_player_removes_from_room_game_mappings():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+
+    room_game.remove_player("p1")
+
+    assert "p1" not in room_game.player_objects
+    assert "p1" not in room_game.players_dict
+    assert all(player.name != "Alice" for player in room_game.game.players)
+
+
+def test_remove_player_also_removes_bet_if_present():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.player_bets["p1"] = 50
+
+    room_game.remove_player("p1")
+
+    assert "p1" not in room_game.player_bets
+
+
+def test_reset_for_next_round_resets_phase_and_clears_bets(monkeypatch):
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.ROUND_COMPLETE
+    room_game.player_bets = {"p1": 50, "p2": 25}
+
+    called = {"reset_round": 0}
+
+    def fake_reset_round():
+        called["reset_round"] += 1
+
+    monkeypatch.setattr(room_game.game, "reset_round", fake_reset_round)
+
+    room_game.reset_for_next_round([])
+
+    assert room_game.phase == GamePhase.WAITING_FOR_BETS
+    assert room_game.player_bets == {}
+    assert room_game.current_player_index == 0
+    assert called["reset_round"] == 1
+
+
+def test_reset_for_next_round_adds_pending_players(monkeypatch):
+    room_game = GameManager().create_game("ROOM1", sample_players())
+
+    monkeypatch.setattr(room_game.game, "reset_round", lambda: None)
+
+    pending = [{"player_id": "p3", "username": "Cara", "sid": "sid3"}]
+    room_game.reset_for_next_round(pending)
+
+    assert "p3" in room_game.player_objects
+    assert room_game.players_dict["p3"]["id"] == "sid3"

--- a/tests/test_rules_and_objects.py
+++ b/tests/test_rules_and_objects.py
@@ -95,3 +95,246 @@ def test_game_determine_winner_player_bust():
     assert outcome == "lose"
     assert payout == 0
 
+class FixedDeck:
+    def __init__(self, cards):
+        self.cards = list(cards)
+
+    def draw_card(self):
+        return self.cards.pop(0)
+
+
+def test_peak_card_returns_expected_card():
+    deck = Deck()
+    first = deck.peak_card(0)
+    assert isinstance(first, Card)
+    assert str(first) == str(deck.cards[0])
+
+
+def test_player_draw_from_deck_adds_card_to_hand():
+    player = Player("Luis")
+    deck = FixedDeck([Card("Hearts", "9")])
+
+    player.draw_from_deck(deck)
+
+    assert len(player.hand) == 1
+    assert str(player.hand[0]) == "9 of Hearts"
+
+
+def test_player_get_hand_returns_hand_reference():
+    player = Player("Luis")
+    player.hand = [Card("Spades", "Ace")]
+
+    hand = player.get_hand()
+
+    assert len(hand) == 1
+    assert str(hand[0]) == "Ace of Spades"
+
+
+def test_player_get_hand_value_uses_hand_value_function():
+    player = Player("Luis")
+    player.hand = [Card("Hearts", "Ace"), Card("Clubs", "7")]
+
+    assert player.get_hand_value() == 18
+
+
+def test_player_hit_without_busting():
+    player = Player("Luis")
+    player.hand = [Card("Hearts", "10")]
+    deck = FixedDeck([Card("Spades", "7")])
+
+    player.hit(deck)
+
+    assert player.get_hand_value() == 17
+    assert player.is_bust is False
+
+
+def test_player_hit_sets_bust_when_over_21():
+    player = Player("Luis")
+    player.hand = [Card("Hearts", "10"), Card("Diamonds", "9")]
+    deck = FixedDeck([Card("Spades", "5")])
+
+    player.hit(deck)
+
+    assert player.get_hand_value() == 24
+    assert player.is_bust is True
+
+
+def test_game_reset_round_clears_dealer_and_player_states():
+    game = Game()
+    player = Player("Luis")
+    player.hand = [Card("Hearts", "10")]
+    player.is_bust = True
+    player.is_stand = True
+    game.add_player(player)
+    game.dealer_hand = [Card("Spades", "Ace")]
+
+    game.reset_round()
+
+    assert game.dealer_hand == []
+    assert player.hand == []
+    assert player.is_bust is False
+    assert player.is_stand is False
+
+
+def test_game_reset_round_rebuilds_and_shuffles_when_deck_low(monkeypatch):
+    game = Game()
+    game.deck.cards = [Card("Hearts", "2")] * 10
+
+    called = {"build": 0, "shuffle": 0}
+
+    def fake_build():
+        called["build"] += 1
+        game.deck.cards = [Card("Spades", "Ace")] * 52
+
+    def fake_shuffle():
+        called["shuffle"] += 1
+
+    monkeypatch.setattr(game.deck, "build_deck", fake_build)
+    monkeypatch.setattr(game.deck, "shuffle", fake_shuffle)
+
+    game.reset_round()
+
+    assert called["build"] == 1
+    assert called["shuffle"] == 1
+    assert len(game.deck.cards) == 52
+
+
+def test_deal_initial_gives_two_cards_to_each_player_and_dealer():
+    game = Game()
+    p1 = Player("Luis")
+    p2 = Player("Bob")
+    game.add_player(p1)
+    game.add_player(p2)
+
+    game.deck = FixedDeck([
+        Card("Hearts", "2"),
+        Card("Hearts", "3"),
+        Card("Hearts", "4"),
+        Card("Hearts", "5"),
+        Card("Spades", "9"),
+        Card("Spades", "10"),
+    ])
+
+    game.deal_initial()
+
+    assert len(p1.hand) == 2
+    assert len(p2.hand) == 2
+    assert len(game.dealer_hand) == 2
+
+
+def test_dealer_play_hits_until_at_least_17():
+    game = Game()
+    game.dealer_hand = [Card("Hearts", "5"), Card("Clubs", "6")]
+    game.deck = FixedDeck([
+        Card("Spades", "4"),
+        Card("Diamonds", "3"),
+    ])
+
+    game.dealer_play()
+
+    assert game.get_dealer_hand_value() >= 17
+
+
+def test_dealer_play_stops_immediately_on_17_or_more():
+    game = Game()
+    game.dealer_hand = [Card("Hearts", "10"), Card("Clubs", "7")]
+    game.deck = FixedDeck([Card("Spades", "4")])
+
+    game.dealer_play()
+
+    assert len(game.dealer_hand) == 2
+    assert game.get_dealer_hand_value() == 17
+
+
+def test_determine_winner_when_dealer_busts():
+    game = Game()
+    player = Player("Luis")
+    player.bet = 50
+    player.hand = [Card("Hearts", "10"), Card("Clubs", "9")]
+    game.dealer_hand = [Card("Spades", "10"), Card("Diamonds", "9"), Card("Hearts", "5")]
+
+    outcome, payout = game.determine_winner(player)
+
+    assert outcome == "win"
+    assert payout == 100
+
+
+def test_determine_winner_when_player_beats_dealer():
+    game = Game()
+    player = Player("Luis")
+    player.bet = 25
+    player.hand = [Card("Hearts", "10"), Card("Clubs", "9")]
+    game.dealer_hand = [Card("Spades", "10"), Card("Diamonds", "7")]
+
+    outcome, payout = game.determine_winner(player)
+
+    assert outcome == "win"
+    assert payout == 50
+
+
+def test_determine_winner_push_returns_bet():
+    game = Game()
+    player = Player("Luis")
+    player.bet = 30
+    player.hand = [Card("Hearts", "10"), Card("Clubs", "8")]
+    game.dealer_hand = [Card("Spades", "9"), Card("Diamonds", "9")]
+
+    outcome, payout = game.determine_winner(player)
+
+    assert outcome == "push"
+    assert payout == 30
+
+
+def test_determine_winner_player_loses():
+    game = Game()
+    player = Player("Luis")
+    player.bet = 40
+    player.hand = [Card("Hearts", "10"), Card("Clubs", "6")]
+    game.dealer_hand = [Card("Spades", "10"), Card("Diamonds", "8")]
+
+    outcome, payout = game.determine_winner(player)
+
+    assert outcome == "lose"
+    assert payout == 0
+
+
+def test_finalize_round_updates_balances_and_results(monkeypatch):
+    game = Game()
+    p1 = Player("Luis")
+    p2 = Player("Bob")
+    p1.bet = 50
+    p2.bet = 25
+    p1.balance = 900
+    p2.balance = 800
+    p1.hand = [Card("Hearts", "10"), Card("Clubs", "9")]
+    p2.hand = [Card("Hearts", "10"), Card("Clubs", "6")]
+    game.add_player(p1)
+    game.add_player(p2)
+    game.dealer_hand = [Card("Spades", "10"), Card("Diamonds", "7")]
+
+    monkeypatch.setattr(game, "dealer_play", lambda: None)
+
+    results = game.finalize_round()
+
+    assert results["Luis"]["outcome"] == "win"
+    assert results["Bob"]["outcome"] == "lose"
+    assert p1.balance == 1000
+    assert p2.balance == 800
+
+
+def test_finalize_round_marks_bust_player_as_bust(monkeypatch):
+    game = Game()
+    p1 = Player("Luis")
+    p1.bet = 20
+    p1.balance = 500
+    p1.is_bust = True
+    p1.hand = [Card("Hearts", "10"), Card("Clubs", "9"), Card("Spades", "5")]
+    game.add_player(p1)
+    game.dealer_hand = [Card("Spades", "10"), Card("Diamonds", "7")]
+
+    monkeypatch.setattr(game, "dealer_play", lambda: None)
+
+    results = game.finalize_round()
+
+    assert results["Luis"]["outcome"] == "lose"
+    assert results["Luis"]["hand_value"] == "BUST"


### PR DESCRIPTION
Adds a second pass of unit tests for src/app.py, covering validation paths for async handlers and singleplayer/game flow checks.


Related to #28