### PR TITLE
fix: natural blackjack pays 3:2 on the bet (#45)

### DIFF
--- a/backend/blackjack/rules_and_objects.py
+++ b/backend/blackjack/rules_and_objects.py
@@ -169,7 +169,7 @@ class Game:
         """
         Determine outcome for a player.
         Returns: ('win' | 'blackjack' | 'push' | 'lose', payout).
-        'blackjack' pays 2x bet plus a 30% bonus on the bet.
+        'blackjack' pays 2x bet plus a 30% bonus on the 2x win (bet 100 -> 260).
         """
         dealer_blackjack = self.is_dealer_blackjack()
         player_blackjack = len(player.hand) == 2 and player.get_hand_value() == 21
@@ -177,8 +177,9 @@ class Game:
         if player_blackjack and dealer_blackjack:
             return ('push', player.bet)
         if player_blackjack:
-            bonus = (player.bet * 3) // 10
-            return ('blackjack', player.bet * 2 + bonus)
+            base = player.bet * 2
+            bonus = (base * 3) // 10
+            return ('blackjack', base + bonus)
         if dealer_blackjack:
             return ('lose', 0)
 

--- a/backend/blackjack/rules_and_objects.py
+++ b/backend/blackjack/rules_and_objects.py
@@ -169,7 +169,7 @@ class Game:
         """
         Determine outcome for a player.
         Returns: ('win' | 'blackjack' | 'push' | 'lose', payout).
-        'blackjack' pays 2x bet plus a 30% bonus on the 2x win (bet 100 -> 260).
+        'blackjack' pays 3:2 on the bet (bet 100 -> 250: 100 stake + 150 winnings).
         """
         dealer_blackjack = self.is_dealer_blackjack()
         player_blackjack = len(player.hand) == 2 and player.get_hand_value() == 21
@@ -177,9 +177,8 @@ class Game:
         if player_blackjack and dealer_blackjack:
             return ('push', player.bet)
         if player_blackjack:
-            base = player.bet * 2
-            bonus = (base * 3) // 10
-            return ('blackjack', base + bonus)
+            winnings = (player.bet * 3) // 2
+            return ('blackjack', player.bet + winnings)
         if dealer_blackjack:
             return ('lose', 0)
 

--- a/tests/test_rules_and_objects.py
+++ b/tests/test_rules_and_objects.py
@@ -298,11 +298,11 @@ def test_determine_winner_player_loses():
     assert payout == 0
 
 
-def test_determine_winner_player_natural_blackjack_pays_2x_bet_plus_30_percent_of_2x():
+def test_determine_winner_player_natural_blackjack_pays_3_to_2():
     """Regression test for issue #45.
 
-    Natural blackjack must pay 2x bet plus 30% of that 2x win,
-    not 30% of the original bet alone. Bet 100 -> payout 260.
+    Natural blackjack pays 3:2 on the bet — bet 100 returns the 100 stake
+    plus 150 in winnings for a total payout of 250.
     """
     game = Game()
     player = Player("Luis")
@@ -313,7 +313,21 @@ def test_determine_winner_player_natural_blackjack_pays_2x_bet_plus_30_percent_o
     outcome, payout = game.determine_winner(player)
 
     assert outcome == "blackjack"
-    assert payout == 260
+    assert payout == 250
+
+
+def test_determine_winner_player_natural_blackjack_3_to_2_small_bet():
+    """Bet 10 on a natural blackjack returns 25 total (10 stake + 15 winnings)."""
+    game = Game()
+    player = Player("Luis")
+    player.bet = 10
+    player.hand = [Card("Hearts", "Ace"), Card("Clubs", "King")]
+    game.dealer_hand = [Card("Spades", "10"), Card("Diamonds", "7")]
+
+    outcome, payout = game.determine_winner(player)
+
+    assert outcome == "blackjack"
+    assert payout == 25
 
 
 def test_determine_winner_player_blackjack_with_dealer_blackjack_is_push():

--- a/tests/test_rules_and_objects.py
+++ b/tests/test_rules_and_objects.py
@@ -298,6 +298,37 @@ def test_determine_winner_player_loses():
     assert payout == 0
 
 
+def test_determine_winner_player_natural_blackjack_pays_2x_bet_plus_30_percent_of_2x():
+    """Regression test for issue #45.
+
+    Natural blackjack must pay 2x bet plus 30% of that 2x win,
+    not 30% of the original bet alone. Bet 100 -> payout 260.
+    """
+    game = Game()
+    player = Player("Luis")
+    player.bet = 100
+    player.hand = [Card("Hearts", "Ace"), Card("Clubs", "King")]
+    game.dealer_hand = [Card("Spades", "10"), Card("Diamonds", "7")]
+
+    outcome, payout = game.determine_winner(player)
+
+    assert outcome == "blackjack"
+    assert payout == 260
+
+
+def test_determine_winner_player_blackjack_with_dealer_blackjack_is_push():
+    game = Game()
+    player = Player("Luis")
+    player.bet = 100
+    player.hand = [Card("Hearts", "Ace"), Card("Clubs", "King")]
+    game.dealer_hand = [Card("Spades", "Ace"), Card("Diamonds", "Queen")]
+
+    outcome, payout = game.determine_winner(player)
+
+    assert outcome == "push"
+    assert payout == 100
+
+
 def test_finalize_round_updates_balances_and_results(monkeypatch):
     game = Game()
     p1 = Player("Luis")


### PR DESCRIPTION
## Summary
Fixes the natural blackjack payout bug in #45. After clarification from the issue author, the correct rule is standard casino **3:2 on the bet**, not a 30% bonus.

Example: bet 100 → total payout 250 (100 stake returned + 150 winnings, i.e. `+150` net).

## Changes
- `backend/blackjack/rules_and_objects.py`: `determine_winner` now returns `player.bet + (player.bet * 3) // 2` on a player natural blackjack. Push on player+dealer blackjack is unchanged.
- `tests/test_rules_and_objects.py`: regression tests for the 3:2 payout at bet 100 (→ 250) and bet 10 (→ 25), plus the existing push case on mutual blackjack.

## Test plan
- [x] `pytest` — 113 passed
- [x] Manual play: dealt natural blackjack with bet 200, observed `+300` net profit (500 total payout) in the UI.

Closes #45