### PR TITLE
fix: show bust card on round end (#46)

### DIFF
--- a/backend/blackjack/game.py
+++ b/backend/blackjack/game.py
@@ -201,19 +201,22 @@ class RoomGame:
 
         if active_players:
             return self.get_game_state()
-        
-        # All players done, dealer's turn
+
+        # All players done, dealer's turn. Build the response from
+        # get_game_state so the final player hands (including the card that
+        # caused the last player to bust) are included — the frontend reads
+        # payload.players to render hands on round_complete.
         self.phase = GamePhase.DEALER_TURN
         results = self.game.finalize_round()
         self.phase = GamePhase.ROUND_COMPLETE
-        
-        return {
-            "phase": self.phase.value,
-            "message": "Round complete",
-            "results": results,
-            "dealer_hand": [str(card) for card in self.game.dealer_hand],
-            "dealer_value": self.game.get_dealer_hand_value(),
-        }
+
+        state = self.get_game_state()
+        state["phase"] = self.phase.value
+        state["message"] = "Round complete"
+        state["results"] = results
+        state["dealer_hand"] = [str(card) for card in self.game.dealer_hand]
+        state["dealer_value"] = self.game.get_dealer_hand_value()
+        return state
     
     def reset_for_next_round(self, new_players: list[dict] | None = None) -> None:
         """Reset for a new round, preserving player_objects insertion order.

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -275,6 +275,44 @@ def test_advance_to_next_player_finalizes_when_no_active_players(monkeypatch):
     assert room_game.phase == GamePhase.ROUND_COMPLETE
 
 
+def test_round_complete_response_includes_player_hands_with_bust_card(monkeypatch):
+    """Regression test for issue #46.
+
+    When the last remaining player busts, the round_complete payload must
+    include each player's full hand (including the card that caused the
+    bust) so the frontend can render it. Previously this response omitted
+    the players array entirely, leaving the frontend stuck on stale state.
+    """
+    from blackjack.rules_and_objects import Card
+
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+
+    p1 = room_game.player_objects["p1"]
+    p2 = room_game.player_objects["p2"]
+
+    p1.is_stand = True
+    p1.hand = [Card("Hearts", "10"), Card("Clubs", "9")]
+    p2.hand = [Card("Hearts", "10"), Card("Clubs", "6"), Card("Spades", "9")]
+    p2.is_bust = True
+
+    monkeypatch.setattr(room_game.game, "finalize_round", lambda: {
+        "Alice": {"outcome": "win"},
+        "Bob": {"outcome": "lose"},
+    })
+    monkeypatch.setattr(room_game.game, "get_dealer_hand_value", lambda: 19)
+    room_game.game.dealer_hand = [Card("Spades", "10"), Card("Diamonds", "9")]
+
+    result = room_game.advance_to_next_player()
+
+    assert result["phase"] == "round_complete"
+    assert "players" in result
+    bob = next(p for p in result["players"] if p["username"] == "Bob")
+    assert bob["is_bust"] is True
+    assert len(bob["hand"]) == 3
+    assert "9 of Spades" in bob["hand"]
+
+
 def test_get_final_state_includes_full_dealer_hand(monkeypatch):
     room_game = GameManager().create_game("ROOM1", sample_players())
     room_game.game.dealer_hand = []


### PR DESCRIPTION
## Summary
Fixes #46. When the last active player busted, their final hit-card was never drawn on screen — the backend's `round_complete` payload from `advance_to_next_player` omitted the `players` array, and the frontend falls back to stale state without it.

The fix builds the round-complete response from `get_game_state()` (the same pattern already used by `_finalize_round_early`), so every player's full hand — including the bust card — is delivered to the client.

## Changes
- `backend/blackjack/game.py`: `advance_to_next_player` now returns `get_game_state()` augmented with `phase`, `message`, `results`, full `dealer_hand`, and `dealer_value`.
- `tests/test_game.py`: regression test asserting `players` is present on round_complete and the busting player's 3-card hand survives.

## Test plan
- [x] `pytest` — 114 passed
- [x] Manual: solo player hit to bust, round-over screen showed all four cards (`Q♣ 2♠ 3♠ 7♥`) with `Value: BUST`.

Closes #46