### PR TITLE
fix: shuffle deck on construction (#51)

### DIFF
--- a/backend/blackjack/rules_and_objects.py
+++ b/backend/blackjack/rules_and_objects.py
@@ -42,6 +42,7 @@ class Deck:
     def __init__(self):
         self.cards = []
         self.build_deck()
+        self.shuffle()
 
     def shuffle(self):
         random.shuffle(self.cards)

--- a/tests/test_rules_and_objects.py
+++ b/tests/test_rules_and_objects.py
@@ -32,6 +32,32 @@ def test_deck_builds_52_cards():
     assert len(deck.cards) == 52
 
 
+def test_deck_is_shuffled_on_construction():
+    """Regression test for issue #51.
+
+    A freshly constructed Deck must not be in the deterministic build order
+    (Hearts 2..Ace, Diamonds 2..Ace, Clubs 2..Ace, Spades 2..Ace). Across
+    several independent decks at least one must differ from that order —
+    otherwise no shuffle happened. Probability of false failure with three
+    independent 52-card shuffles landing in the exact build order is
+    effectively zero.
+    """
+    built_order = [f"{rank} of {suit}"
+                   for suit in ["Hearts", "Diamonds", "Clubs", "Spades"]
+                   for rank in ["2", "3", "4", "5", "6", "7", "8", "9",
+                                "10", "Jack", "Queen", "King", "Ace"]]
+    decks = [[str(c) for c in Deck().cards] for _ in range(3)]
+    assert any(d != built_order for d in decks)
+
+
+def test_two_fresh_decks_have_different_order():
+    """Two independent Deck constructions should (almost certainly) produce
+    different card orders; if they match, the RNG is effectively frozen."""
+    a = [str(c) for c in Deck().cards]
+    b = [str(c) for c in Deck().cards]
+    assert a != b
+
+
 def test_draw_card_reduces_deck_size():
     deck = Deck()
     original_size = len(deck.cards)


### PR DESCRIPTION
## Summary
Fixes #51. The reporter observed that the deck was shuffled the same way every time. The root cause isn't a seeding issue — Python's `random.shuffle` is auto-seeded from OS entropy at module import. The actual bug: `Deck.__init__` called `build_deck()` but never shuffled, and `reset_round` only reshuffles when fewer than 20 cards remain. So every session opened with `Hearts 2, Hearts 3, …` in deterministic build order.

Fix: call `self.shuffle()` once in `Deck.__init__` after `build_deck`. `reset_round`'s low-deck reshuffle is unchanged.

## Changes
- `backend/blackjack/rules_and_objects.py`: shuffle in `Deck.__init__` after `build_deck`.
- `tests/test_rules_and_objects.py`: regression tests asserting a fresh deck is not in built order and two independent decks produce different orders.

## Test plan
- [x] `pytest` — 116 passed
- [x] Manual: refreshed the page multiple times; opening deal differs on each session.

Closes #51