### PR TITLE
feat: split room UI into columns and keep table visible

### DIFF
--- a/backend/blackjack/frontend/index.html
+++ b/backend/blackjack/frontend/index.html
@@ -31,12 +31,42 @@
     }
 
     #app {
-      max-width: 700px;
+      max-width: 1120px;
       width: 100%;
+    }
+
+    #lobby {
+      max-width: 700px;
+      margin: 0 auto;
+    }
+
+    #room {
+      width: 100%;
+    }
+
+    .room-layout {
+      display: grid;
+      grid-template-columns: minmax(0, 7fr) minmax(260px, 3fr);
+      gap: 16px;
+      align-items: start;
+    }
+
+    .room-main,
+    .room-side {
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .room-main .panel,
+    .room-side .panel {
+      margin-bottom: 0;
     }
 
     .ascii-header {
       margin: 0 auto 24px;
+      max-width: 700px;
       text-align: center;
       font-size: 16px;
       line-height: 1.2;
@@ -132,6 +162,51 @@
       flex-wrap: wrap;
     }
 
+    .room-action-row {
+      align-items: center;
+      flex-wrap: nowrap;
+    }
+
+    .room-code-inline {
+      display: flex;
+      flex-wrap: nowrap;
+      align-items: center;
+      gap: 10px;
+      min-width: 280px;
+      padding: 8px 14px;
+      border: 2px solid var(--amber);
+      color: var(--amber);
+    }
+
+    .room-code-inline .code-label {
+      font-size: 18px;
+      color: var(--dim-green);
+      letter-spacing: 0.08em;
+      white-space: nowrap;
+    }
+
+    .room-code-inline .room-code {
+      font-size: 26px;
+      letter-spacing: 3px;
+      color: var(--amber);
+      text-shadow: 0 0 12px rgba(255, 170, 0, 0.45);
+      white-space: nowrap;
+    }
+
+    .room-code-inline #inviteBtn {
+      margin: 0;
+      padding: 4px 10px;
+      font-size: 20px;
+      line-height: 1;
+      white-space: nowrap;
+    }
+
+    .room-code-inline #inviteFlash {
+      font-size: 16px;
+      color: var(--green);
+      white-space: nowrap;
+    }
+
     .error {
       color: var(--red);
       font-size: 20px;
@@ -164,7 +239,7 @@
 
     #chatBox {
       border: 1px solid var(--dim-green);
-      height: 180px;
+      height: 150px;
       overflow-y: auto;
       padding: 8px;
       margin-bottom: 8px;
@@ -177,8 +252,10 @@
     .chat-input-row {
       display: flex;
       gap: 8px;
+      flex-wrap: wrap;
     }
-    .chat-input-row input { flex: 1; margin-bottom: 0; }
+    .chat-input-row input { flex: 1; min-width: 0; margin-bottom: 0; }
+    .chat-input-row .btn { flex-shrink: 0; }
     .btn-ai {
       color: var(--amber);
       border-color: var(--amber);
@@ -316,13 +393,43 @@
       );
       z-index: 999;
     }
+
+    @media (max-width: 1100px) {
+      .room-action-row {
+        flex-wrap: wrap;
+      }
+
+      .room-code-inline {
+        flex-wrap: wrap;
+        min-width: 0;
+        width: 100%;
+      }
+
+      .room-code-inline #inviteFlash {
+        width: 100%;
+      }
+    }
+
+    @media (max-width: 900px) {
+      .room-layout {
+        grid-template-columns: 1fr;
+      }
+
+      .room-side {
+        order: 1;
+      }
+
+      .room-main {
+        order: 2;
+      }
+    }
   </style>
 </head>
 <body>
   <div class="scanline"></div>
 
   <div id="app">
-    <div class="ascii-header">
+    <div class="ascii-header" id="gameTitleHeader">
       <div class="title-line">♠ ♥ BLACKJACK ♣ ♦</div>
       <div class="sub-line">~ multiplayer ~</div>
     </div>
@@ -350,73 +457,75 @@
 
     <!-- ── ROOM SCREEN ──────────────────────── -->
     <div id="room" class="hidden">
-      <div class="panel" id="roomCodePanel">
-        <div class="panel-title">&gt; TABLE CODE</div>
-        <div class="room-code" id="roomCodeDisplay"></div>
-        <p style="font-size:18px; color:var(--dim-green); margin-top:4px;">
-          Share this code with your friends to join.
-        </p>
-        <button class="btn btn-amber hidden" id="inviteBtn" onclick="revealInvite()"
-                style="margin-top:8px;">[ INVITE ]</button>
-        <p id="inviteFlash" class="hidden" style="font-size:18px; color:var(--amber); margin-top:6px;"></p>
-      </div>
+      <div class="room-layout">
+        <div class="room-main">
+          <div id="gameTable" class="panel hidden">
+            <div class="panel-title">&gt; TABLE</div>
+            <div class="status-line" id="statusMsg">Waiting for game to start...</div>
 
-      <div class="panel">
-        <div class="panel-title">&gt; PLAYERS</div>
-        <ul class="player-list" id="playerList"></ul>
-      </div>
+            <div class="dealer-area">
+              <div class="label">DEALER <span id="dealerValue"></span></div>
+              <div class="hand-row" id="dealerHand"></div>
+            </div>
 
-      <div class="panel">
-        <div class="panel-title">&gt; CHAT</div>
-        <div id="chatBox"></div>
-        <div class="chat-input-row">
-          <input type="text" id="chatInput" placeholder="type a message..."
-                 onkeydown="if(event.key==='Enter')sendChat()" />
-          <button class="btn btn-ai" id="aiHelpBtn" onclick="askAIHelp()">AI HELP</button>
-          <button class="btn" onclick="sendChat()">SEND</button>
-        </div>
-      </div>
+            <div class="seats-grid" id="seatsContainer"></div>
 
-      <div id="gameTable" class="panel hidden">
-        <div class="panel-title">&gt; TABLE</div>
-        <div class="status-line" id="statusMsg">Waiting for game to start...</div>
+            <div class="results-panel hidden" id="resultsBox"></div>
 
-        <div class="dealer-area">
-          <div class="label">DEALER <span id="dealerValue"></span></div>
-          <div class="hand-row" id="dealerHand"></div>
-        </div>
-
-        <div class="seats-grid" id="seatsContainer"></div>
-
-        <div class="results-panel hidden" id="resultsBox"></div>
-
-        <div class="controls" id="controlsPanel">
-          <div class="chip-row" id="chipRow">
-            <button class="chip" onclick="addChip(10)" data-chip="10">+10</button>
-            <button class="chip" onclick="addChip(25)" data-chip="25">+25</button>
-            <button class="chip" onclick="addChip(50)" data-chip="50">+50</button>
-            <button class="chip" onclick="addChip(100)" data-chip="100">+100</button>
-            <button class="chip" onclick="clearBet()">CLEAR</button>
-            <input type="number" id="betInput" min="1" value="0" />
+            <div class="controls" id="controlsPanel">
+              <div class="chip-row" id="chipRow">
+                <button class="chip" onclick="addChip(10)" data-chip="10">+10</button>
+                <button class="chip" onclick="addChip(25)" data-chip="25">+25</button>
+                <button class="chip" onclick="addChip(50)" data-chip="50">+50</button>
+                <button class="chip" onclick="addChip(100)" data-chip="100">+100</button>
+                <button class="chip" onclick="clearBet()">CLEAR</button>
+                <input type="number" id="betInput" min="1" value="0" />
+              </div>
+              <div class="btn-row">
+                <button class="btn" id="betBtn" onclick="placeBet()" disabled>[ PLACE BET ]</button>
+                <button class="btn" id="hitBtn" onclick="hit()" disabled>[ HIT ]</button>
+                <button class="btn btn-amber" id="standBtn" onclick="stand()" disabled>[ STAND ]</button>
+              </div>
+            </div>
           </div>
-          <div class="btn-row">
-            <button class="btn" id="betBtn" onclick="placeBet()" disabled>[ PLACE BET ]</button>
-            <button class="btn" id="hitBtn" onclick="hit()" disabled>[ HIT ]</button>
-            <button class="btn btn-amber" id="standBtn" onclick="stand()" disabled>[ STAND ]</button>
+
+          <div class="btn-row room-action-row" style="margin-top:8px;">
+            <button class="btn btn-amber hidden" id="startGameBtn" onclick="startGame()">[ START GAME ]</button>
+            <button class="btn btn-amber hidden" id="nextRoundBtn" onclick="nextRound()">[ NEXT ROUND ]</button>
+            <button class="btn" onclick="toggleReady()">[ READY ]</button>
+            <button class="btn btn-red" onclick="leaveRoom()">[ LEAVE ]</button>
+
+            <div class="room-code-inline">
+              <span class="code-label">TABLE</span>
+              <div class="room-code" id="roomCodeDisplay"></div>
+              <button class="btn btn-amber hidden" id="inviteBtn" onclick="revealInvite()">[ INVITE ]</button>
+              <span id="inviteFlash" class="hidden"></span>
+            </div>
+          </div>
+
+          <p id="waitingMsg" style="margin-top:8px; font-size:20px;">
+            <span class="blink">▌</span> Waiting for players...
+          </p>
+        </div>
+
+        <div class="room-side">
+          <div class="panel">
+            <div class="panel-title">&gt; CHAT</div>
+            <div id="chatBox"></div>
+            <div class="chat-input-row">
+              <input type="text" id="chatInput" placeholder="type a message..."
+                     onkeydown="if(event.key==='Enter')sendChat()" />
+              <button class="btn btn-ai" id="aiHelpBtn" onclick="askAIHelp()">AI HELP</button>
+              <button class="btn" onclick="sendChat()">SEND</button>
+            </div>
+          </div>
+
+          <div class="panel">
+            <div class="panel-title">&gt; PLAYERS</div>
+            <ul class="player-list" id="playerList"></ul>
           </div>
         </div>
       </div>
-
-      <div class="btn-row" style="margin-top:8px;">
-        <button class="btn btn-amber hidden" id="startGameBtn" onclick="startGame()">[ START GAME ]</button>
-        <button class="btn btn-amber hidden" id="nextRoundBtn" onclick="nextRound()">[ NEXT ROUND ]</button>
-        <button class="btn" onclick="toggleReady()">[ READY ]</button>
-        <button class="btn btn-red" onclick="leaveRoom()">[ LEAVE ]</button>
-      </div>
-
-      <p id="waitingMsg" style="margin-top:12px; font-size:20px;">
-        <span class="blink">▌</span> Waiting for players...
-      </p>
     </div>
   </div>
 
@@ -433,6 +542,7 @@
     // ── DOM refs ──────────────────────────────
     const $lobby     = document.getElementById("lobby");
     const $room      = document.getElementById("room");
+    const $gameTitleHeader = document.getElementById("gameTitleHeader");
     const $joinPanel = document.getElementById("joinPanel");
     const $lobbyErr  = document.getElementById("lobbyError");
     const $username  = document.getElementById("usernameInput");
@@ -457,6 +567,7 @@
     let lastDealerValue = null;
     let aiHelpTimeoutId = null;
     let aiHelpRequestToken = 0;
+    let inviteCodePinnedVisible = false;
 
     const $gameTable   = document.getElementById("gameTable");
     const $statusMsg   = document.getElementById("statusMsg");
@@ -471,7 +582,6 @@
     const $startGameBtn = document.getElementById("startGameBtn");
     const $nextRoundBtn = document.getElementById("nextRoundBtn");
     const $chipRow     = document.getElementById("chipRow");
-    const $roomCodePanel = document.getElementById("roomCodePanel");
     const $inviteBtn   = document.getElementById("inviteBtn");
     const $inviteFlash = document.getElementById("inviteFlash");
 
@@ -487,6 +597,7 @@
       if (!$room.classList.contains("hidden")) {
         $room.classList.add("hidden");
         $lobby.classList.remove("hidden");
+        $gameTitleHeader.classList.remove("hidden");
         $chatBox.innerHTML = "";
         $players.innerHTML = "";
         currentRoomState = null;
@@ -571,7 +682,9 @@
     function enterRoom(code) {
       $lobby.classList.add("hidden");
       $room.classList.remove("hidden");
+      $gameTitleHeader.classList.add("hidden");
       $roomCode.textContent = code;
+      inviteCodePinnedVisible = false;
       $chatInput.value = "";
       applyRoomCodeVisibility();
     }
@@ -586,7 +699,7 @@
         && currentRoomState.players.some(
              (p) => p.id === currentRoomState.hostId && p.player_id === myPlayerId
            );
-      if (isSolo && alone) {
+      if (isSolo && alone && !inviteCodePinnedVisible) {
         $roomCode.classList.add("hidden");
         $inviteBtn.classList.toggle("hidden", !iAmHost);
       } else {
@@ -598,11 +711,13 @@
 
     function revealInvite() {
       const code = $roomCode.textContent;
+      inviteCodePinnedVisible = true;
       $roomCode.classList.remove("hidden");
+      $inviteBtn.classList.add("hidden");
       if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(code).catch(() => {});
       }
-      $inviteFlash.textContent = "> Code copied: " + code;
+      $inviteFlash.textContent = "COPIED";
       $inviteFlash.classList.remove("hidden");
       setTimeout(() => $inviteFlash.classList.add("hidden"), 2500);
     }
@@ -623,6 +738,7 @@
       socket.emit("room:leave");
       $room.classList.add("hidden");
       $lobby.classList.remove("hidden");
+      $gameTitleHeader.classList.remove("hidden");
       $chatBox.innerHTML = "";
       $players.innerHTML = "";
       currentRoomState = null;
@@ -633,6 +749,7 @@
       myUsername = null;
       myPlayerId = null;
       isSinglePlayer = false;
+        inviteCodePinnedVisible = false;
       $gameTable.classList.add("hidden");
       $startGameBtn.classList.add("hidden");
       $nextRoundBtn.classList.add("hidden");


### PR DESCRIPTION
## Summary
This PR addresses issue #57 by redesigning the in-room gameplay screen so the table remains visible and players no longer need to scroll constantly between gameplay and chat.

## What Changed
- Reworked room screen into a two-column layout for desktop:
  - Left: gameplay/table-centric content
  - Right: chat and players
- Reordered right-side content to:
  - Chat
  - Players
- Moved table code display into a compact inline code pill in the action row (beside READY/LEAVE)
- Hid the main game title header while inside room view to recover vertical space
- Kept invite/reveal behavior for singleplayer-origin rooms, including pinned code visibility after reveal
- Added responsive behavior for narrower widths to avoid overflow while keeping structure simple

## Files Changed
- `backend/blackjack/frontend/index.html`

## Testing
- Automated:
  - `uv run pytest -q`
  - Result: `114 passed, 1 warning`
- Manual/local:
  - Verified app loads at local port 3000
  - Verified socket connection and room create/join flows
  - Verified normal chat event path works
  - Verified AI Help path works when server is started via Doppler (`doppler run -- uv run python -m blackjack.app`)

## Notes
- This is a frontend-focused change; backend game logic was not modified.
- Kept implementation in a single file to avoid unnecessary complexity and preserve current architecture.

Closes #57