### PR TITLE
Add double down support for blackjack hands

### DIFF
--- a/backend/blackjack/app.py
+++ b/backend/blackjack/app.py
@@ -243,9 +243,10 @@ async def room_join(sid, payload=None):
     )
     await broadcast_room_update(room_code)
 
-    # Spectator gets a snapshot of the in-flight game so the table renders for them.
+    # Spectator gets a snapshot of the current game state so the table renders correctly.
     if is_spectator and game:
-        await sio.emit("game:state", game.get_game_state(), to=sid)
+        state = game.get_final_state() if game.phase == GamePhase.ROUND_COMPLETE else game.get_game_state()
+        await sio.emit("game:state", state, to=sid)
 
     return {"success": True, "code": room_code, "player_id": player["player_id"], "spectator": is_spectator}
 

--- a/backend/blackjack/app.py
+++ b/backend/blackjack/app.py
@@ -589,6 +589,25 @@ async def game_stand(sid, *args):
     await sio.emit("game:state", result, room=current_room)
     return result
 
+@sio.on("game:double-down")
+async def game_double_down(sid, *args):
+    """Player doubles down."""
+    current_room = player_rooms.get(sid)
+    if not current_room:
+        return {"error": "Not in a room."}
+
+    game = game_manager.get_game(current_room)
+    if not game:
+        return {"error": "No active game."}
+
+    player_id = player_info[sid]["player_id"]
+    result = game.double_down(player_id)
+
+    if "error" in result:
+        return result
+
+    await sio.emit("game:state", result, room=current_room)
+    return result
 
 @sio.on("game:get-state")
 async def game_get_state(sid, *args):

--- a/backend/blackjack/game.py
+++ b/backend/blackjack/game.py
@@ -192,6 +192,20 @@ class RoomGame:
         player.stand()
         return self.advance_to_next_player()
     
+    def double_down(self, player_id: str) -> dict:
+        """Player doubles down: double bet, take one card, and end turn."""
+        if self.phase != GamePhase.PLAYING:
+            return {"error": "Not in playing phase."}
+
+        player = self.player_objects.get(player_id)
+        if not player:
+            return {"error": "Player not found."}
+
+        if not player.double_down(self.game.deck):
+            return {"error": "Double down not allowed."}
+
+        return self.advance_to_next_player()
+
     def advance_to_next_player(self) -> dict:
         """Move to next active player or dealer."""
         self.current_player_index = self._next_active_index(self.current_player_index + 1)

--- a/backend/blackjack/rules_and_objects.py
+++ b/backend/blackjack/rules_and_objects.py
@@ -119,6 +119,33 @@ class Player:
     def stand(self):
         """Player chooses to stand."""
         self.is_stand = True
+   
+    def can_double_down(self) -> bool:
+        """A player can double down only on their initial two cards totaling 9, 10, or 11,
+        and only if they can afford to match their current bet."""
+        return (
+            len(self.hand) == 2
+            and self.get_hand_value() in (9, 10, 11)
+            and self.bet > 0
+            and self.balance >= self.bet
+            and not self.is_bust
+            and not self.is_stand
+        )
+
+    def double_down(self, deck) -> bool:
+        """Double the current bet, draw exactly one card, then stand."""
+        if not self.can_double_down():
+            return False
+
+        self.balance -= self.bet
+        self.bet *= 2
+        self.draw_from_deck(deck)
+
+        if self.get_hand_value() > 21:
+            self.is_bust = True
+
+        self.is_stand = True
+        return True
     
 class Game:
     def __init__(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -519,12 +519,19 @@ def test_ai_help_success(monkeypatch):
 
     app_module.player_rooms["sid1"] = "ROOM1"
     app_module.rooms["ROOM1"] = {
-        "players": [{"id": "sid1", "username": "Luis"}]
+        "players": [{"id": "sid1", "username": "Luis", "player_id": "p1"}]
     }
+
+    fake_player = SimpleNamespace(get_hand_string=lambda: "Ace of Hearts, King of Spades")
+    fake_game = SimpleNamespace(
+        player_objects={"p1": fake_player},
+        game=SimpleNamespace(get_dealer_hand_string=lambda: "9 of Clubs")
+    )
 
     fake_chat = SimpleNamespace(ask=lambda prompt: " Hit on 11 versus dealer 10. ")
     monkeypatch.setattr("blackjack.app.chat", fake_chat)
     monkeypatch.setattr("blackjack.app.time.monotonic", lambda: 200.0)
+    monkeypatch.setattr("blackjack.app.game_manager.get_game", lambda room_code: fake_game)
 
     result = asyncio.run(app_module.ai_help("sid1", {"query": "what should I do?"}))
 
@@ -540,12 +547,19 @@ def test_ai_help_returns_error_on_empty_response(monkeypatch):
 
     app_module.player_rooms["sid1"] = "ROOM1"
     app_module.rooms["ROOM1"] = {
-        "players": [{"id": "sid1", "username": "Luis"}]
+        "players": [{"id": "sid1", "username": "Luis", "player_id": "p1"}]
     }
+
+    fake_player = SimpleNamespace(get_hand_string=lambda: "10 of Hearts, 6 of Spades")
+    fake_game = SimpleNamespace(
+        player_objects={"p1": fake_player},
+        game=SimpleNamespace(get_dealer_hand_string=lambda: "King of Clubs")
+    )
 
     fake_chat = SimpleNamespace(ask=lambda prompt: "   ")
     monkeypatch.setattr("blackjack.app.chat", fake_chat)
     monkeypatch.setattr("blackjack.app.time.monotonic", lambda: 300.0)
+    monkeypatch.setattr("blackjack.app.game_manager.get_game", lambda room_code: fake_game)
 
     result = asyncio.run(app_module.ai_help("sid1", {"query": "help"}))
 
@@ -755,6 +769,40 @@ def test_index_html_is_served_on_root():
 
     asyncio.run(_test())
 
+def test_room_join_spectator_gets_final_state_when_round_complete(monkeypatch):
+    app_module.rooms.clear()
+    app_module.player_rooms.clear()
+    app_module.player_info.clear()
 
+    app_module.player_info["sid2"] = {"player_id": "p2"}
+    app_module.rooms["ROOM1"] = {
+        "code": "ROOM1",
+        "host_id": "sid1",
+        "players": [{"id": "sid1", "username": "Luis", "player_id": "p1", "ready": False}],
+        "game_started": True,
+    }
 
+    fake_game = SimpleNamespace(
+        phase=app_module.GamePhase.ROUND_COMPLETE,
+        get_game_state=lambda: {"phase": "round_complete", "dealer_hand": ["hidden"]},
+        get_final_state=lambda: {"phase": "round_complete", "dealer_hand": ["10 of Hearts", "7 of Clubs"]},
+    )
 
+    mock_enter = AsyncMock()
+    mock_emit = AsyncMock()
+    mock_broadcast = AsyncMock()
+
+    monkeypatch.setattr("blackjack.app.sio.enter_room", mock_enter)
+    monkeypatch.setattr("blackjack.app.sio.emit", mock_emit)
+    monkeypatch.setattr("blackjack.app.broadcast_room_update", mock_broadcast)
+    monkeypatch.setattr("blackjack.app.game_manager.get_game", lambda code: fake_game)
+
+    result = asyncio.run(app_module.room_join("sid2", {"username": "Bob", "code": "ROOM1"}))
+
+    assert result["success"] is True
+    assert result["spectator"] is True
+
+    emits = mock_emit.await_args_list
+    game_state_calls = [call for call in emits if call.args and call.args[0] == "game:state"]
+    assert game_state_calls
+    assert game_state_calls[-1].args[1]["dealer_hand"] == ["10 of Hearts", "7 of Clubs"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,6 +29,7 @@ from blackjack.app import (
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from blackjack.app import game_double_down
 import blackjack.app as app_module
 
 def setup_function():
@@ -806,3 +807,40 @@ def test_room_join_spectator_gets_final_state_when_round_complete(monkeypatch):
     game_state_calls = [call for call in emits if call.args and call.args[0] == "game:state"]
     assert game_state_calls
     assert game_state_calls[-1].args[1]["dealer_hand"] == ["10 of Hearts", "7 of Clubs"]
+
+def test_game_double_down_requires_room_membership():
+    result = asyncio.run(game_double_down("sid1"))
+    assert result["error"] == "Not in a room."
+
+
+def test_game_double_down_requires_active_game(monkeypatch):
+    app_module.player_rooms.clear()
+    app_module.player_rooms["sid1"] = "ROOM1"
+
+    monkeypatch.setattr("blackjack.app.game_manager.get_game", lambda room: None)
+
+    result = asyncio.run(game_double_down("sid1"))
+
+    assert result["error"] == "No active game."
+
+
+def test_game_double_down_success_emits_state(monkeypatch):
+    app_module.player_rooms.clear()
+    app_module.player_info.clear()
+
+    app_module.player_rooms["sid1"] = "ROOM1"
+    app_module.player_info["sid1"] = {"player_id": "p1"}
+
+    fake_game = SimpleNamespace(
+        double_down=lambda player_id: {"phase": "dealer_turn"}
+    )
+
+    mock_emit = AsyncMock()
+
+    monkeypatch.setattr("blackjack.app.game_manager.get_game", lambda room: fake_game)
+    monkeypatch.setattr("blackjack.app.sio.emit", mock_emit)
+
+    result = asyncio.run(game_double_down("sid1"))
+
+    assert result == {"phase": "dealer_turn"}
+    mock_emit.assert_awaited_once_with("game:state", {"phase": "dealer_turn"}, room="ROOM1")

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -384,3 +384,45 @@ def test_reset_for_next_round_adds_pending_players(monkeypatch):
 
     assert "p3" in room_game.player_objects
     assert room_game.players_dict["p3"]["id"] == "sid3"
+
+def test_double_down_rejects_when_not_in_playing_phase():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.WAITING_FOR_BETS
+
+    result = room_game.double_down("p1")
+
+    assert result["error"] == "Not in playing phase."
+
+
+def test_double_down_rejects_unknown_player():
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+
+    result = room_game.double_down("bad_player")
+
+    assert result["error"] == "Player not found."
+
+
+def test_double_down_rejects_when_not_allowed(monkeypatch):
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+    player = room_game.player_objects["p1"]
+
+    monkeypatch.setattr(player, "double_down", lambda deck: False)
+
+    result = room_game.double_down("p1")
+
+    assert result["error"] == "Double down not allowed."
+
+
+def test_double_down_success_advances_turn(monkeypatch):
+    room_game = GameManager().create_game("ROOM1", sample_players())
+    room_game.phase = GamePhase.PLAYING
+    player = room_game.player_objects["p1"]
+
+    monkeypatch.setattr(player, "double_down", lambda deck: True)
+    monkeypatch.setattr(room_game, "advance_to_next_player", lambda: {"phase": "dealer_turn"})
+
+    result = room_game.double_down("p1")
+
+    assert result == {"phase": "dealer_turn"}

--- a/tests/test_rules_and_objects.py
+++ b/tests/test_rules_and_objects.py
@@ -383,3 +383,61 @@ def test_finalize_round_marks_bust_player_as_bust(monkeypatch):
 
     assert results["Luis"]["outcome"] == "lose"
     assert results["Luis"]["hand_value"] == "BUST"
+
+def test_player_can_double_down_on_two_card_nine():
+    player = Player("Luis")
+    player.bet = 50
+    player.balance = 200
+    player.hand = [Card("Hearts", "4"), Card("Spades", "5")]
+
+    assert player.can_double_down() is True
+
+
+def test_player_cannot_double_down_on_wrong_total():
+    player = Player("Luis")
+    player.bet = 50
+    player.balance = 200
+    player.hand = [Card("Hearts", "10"), Card("Spades", "2")]
+
+    assert player.can_double_down() is False
+
+
+def test_player_cannot_double_down_with_more_than_two_cards():
+    player = Player("Luis")
+    player.bet = 50
+    player.balance = 200
+    player.hand = [Card("Hearts", "2"), Card("Spades", "3"), Card("Clubs", "4")]
+
+    assert player.can_double_down() is False
+
+
+def test_player_double_down_doubles_bet_draws_once_and_stands():
+    player = Player("Luis")
+    player.bet = 50
+    player.balance = 200
+    player.hand = [Card("Hearts", "4"), Card("Spades", "5")]
+    deck = FixedDeck([Card("Clubs", "10")])
+
+    result = player.double_down(deck)
+
+    assert result is True
+    assert player.bet == 100
+    assert player.balance == 150
+    assert len(player.hand) == 3
+    assert player.is_stand is True
+    assert player.is_bust is False
+
+
+def test_player_double_down_can_bust():
+    player = Player("Luis")
+    player.bet = 50
+    player.balance = 200
+    player.hand = [Card("Hearts", "5"), Card("Spades", "6")]  # total 11
+    deck = FixedDeck([Card("Clubs", "King")])
+
+    result = player.double_down(deck)
+
+    assert result is True
+    assert player.is_bust is False
+    assert player.get_hand_value() == 21
+    assert player.is_stand is True


### PR DESCRIPTION
Implements double down in the blackjack backend and adds tests for player, game, and socket handler behavior.

Closes #54